### PR TITLE
providing a linux build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ C:\Extensions\scribd-downloader\
 
 ### Step 2 — Build the extension
 
-Open the folder you just extracted and **double-click `build.bat`**.
+Open the folder you just extracted and run the build script for your operating system:
+
+- **Windows:** Double-click `build.bat`
+- **Linux / macOS:** Run `bash build.sh` in your terminal
 
 This script will automatically generate two ready-to-install folders:
 
@@ -69,7 +72,7 @@ scribd-downloader/
 └── ...
 ```
 
-> ℹ️ If nothing happens when you double-click, right-click `build.bat` and select **"Run as administrator"**.
+> ℹ️ If nothing happens when you run the script, ensure you have the necessary permissions (e.g., `chmod +x build.sh` on Linux).
 
 ---
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Scribd Premium Downloader - Constructor (Build)
+# This script generates the 'chrome' and 'firefox' directories for browser installation.
+
+echo ""
+echo "  ======================================================"
+echo "     SCRIBD PREMIUM DOWNLOADER - SYSTEM BUILDER"
+echo "  ======================================================"
+echo ""
+echo "  Iniciando proceso de compilacion y empaquetado..."
+echo ""
+
+# -- Definition of paths
+CHROME_OUT="./chrome"
+FIREFOX_OUT="./firefox"
+SHARED="./src/shared"
+SRC_CHROME="./src/chrome"
+SRC_FIREFOX="./src/firefox"
+
+# -- Check that src/ folders exist before doing anything
+if [ ! -d "$SHARED" ]; then
+    echo "  [ERROR] Could not find $SHARED/  --  make sure you extracted the ZIP correctly."
+    exit 1
+fi
+if [ ! -d "$SRC_CHROME" ]; then
+    echo "  [ERROR] Could not find $SRC_CHROME/  --  make sure you extracted the ZIP correctly."
+    exit 1
+fi
+if [ ! -d "$SRC_FIREFOX" ]; then
+    echo "  [ERROR] Could not find $SRC_FIREFOX/  --  make sure you extracted the ZIP correctly."
+    exit 1
+fi
+
+# -- Build Chrome package
+echo "  Building chrome/ ..."
+rm -rf "$CHROME_OUT"
+mkdir -p "$CHROME_OUT"
+cp -r "$SHARED"/* "$CHROME_OUT/"
+cp -r "$SRC_CHROME"/* "$CHROME_OUT/"
+echo "  ---> Version Chrome generada con exito en carpeta /chrome"
+
+# -- Build Firefox package
+echo "  Building firefox/ ..."
+rm -rf "$FIREFOX_OUT"
+mkdir -p "$FIREFOX_OUT"
+cp -r "$SHARED"/* "$FIREFOX_OUT/"
+cp -r "$SRC_FIREFOX"/* "$FIREFOX_OUT/"
+echo "  ---> Version Firefox generada con exito en carpeta /firefox"
+
+echo ""
+echo "  ======================================================"
+echo "              Done! Show install instructions"
+echo "  ======================================================"
+echo ""
+echo "  Done! Now install the extension in your browser:"
+echo ""
+echo "   [ CHROME / EDGE / BRAVE ]"
+echo "     1. Go to  chrome://extensions"
+echo "     2. Enable \"Developer mode\" [top-right switch]"
+echo "     3. Click \"Load unpacked\"  ->  select the  chrome/  folder"
+echo ""
+echo "   [ MOZILLA FIREFOX ]"
+echo "     1. Go to  about:debugging#/runtime/this-firefox"
+echo "     2. Click \"Load Temporary Add-on...\""
+echo "     3. Open the  firefox/  folder  ->  select  manifest.json"
+echo ""


### PR DESCRIPTION
- Added a Linux build script (build.sh): Created a new bash script to automate the construction of both Chrome and Firefox extension packages. It verifies the existence of the source directories, creates the output folders, and copies the necessary files into them.

 - Updated README.md documentation:
     - Modified the build instructions to support multiple operating systems, providing clear steps for Windows (build.bat), Linux, and macOS (build.sh).
     - Updated the troubleshooting note to include a reminder to grant execution permissions (e.g., chmod +x build.sh) for Linux users.